### PR TITLE
add proxy & update gradle, spring boot, jdk

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,22 +1,6 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
-
 name: Test and deploy
 
 on: [push]
-
-# on:
-#   push:
-#     branches: [ "main" ]
-#   pull_request:
-#     branches: [ "main" ]
-
-# permissions:
-#   contents: read
 
 jobs:
   build:
@@ -24,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'corretto'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'io.github.tttol'
-version = "1.1.6"
+version = "1.1.7"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,16 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.0.1'
+    id 'org.springframework.boot' version '3.2.5'
     id 'io.spring.dependency-management' version '1.1.0'
 }
 
 group = 'io.github.tttol'
 version = "1.1.6"
-sourceCompatibility = '17'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 
 configurations {
     compileOnly {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/github/tttol/mrls/config/RestClientConfig.java
+++ b/src/main/java/io/github/tttol/mrls/config/RestClientConfig.java
@@ -1,0 +1,43 @@
+package io.github.tttol.mrls.config;
+
+import io.micrometer.common.util.StringUtils;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.util.Timeout;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+@Configuration
+public class RestClientConfig {
+
+  @Value("${app.proxy.host}")
+  private String proxyHost;
+
+  @Value("${app.proxy.port}")
+  private int proxyPort;
+
+  @Bean
+  public RestClient restClient() {
+    if (StringUtils.isBlank(proxyHost)) {
+        return RestClient.create();
+    }
+
+    var httpClient = HttpClients.custom()
+            .setProxy(new HttpHost(proxyHost, proxyPort))
+            .build();
+    var httpComponentsClientHttpRequestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+
+    return RestClient.builder()
+            .requestFactory(httpComponentsClientHttpRequestFactory)
+            .build();
+  }
+}

--- a/src/main/java/io/github/tttol/mrls/external/GitLabApiExecutor.java
+++ b/src/main/java/io/github/tttol/mrls/external/GitLabApiExecutor.java
@@ -1,26 +1,27 @@
 package io.github.tttol.mrls.external;
 
-import io.github.tttol.mrls.dto.GitLabMergeRequestApiResponseDto;
-import io.github.tttol.mrls.exception.GitLabApiException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
-import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
+
+import io.github.tttol.mrls.dto.GitLabMergeRequestApiResponseDto;
+import io.github.tttol.mrls.exception.GitLabApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class GitLabApiExecutor {
 
-  private final RestTemplate restTemplate;
+  private final RestClient restClient;
 
   @Value("${app.gitlab.api.endpoint}")
   private String endpoint;
@@ -28,21 +29,21 @@ public class GitLabApiExecutor {
   private String projectAccessToken;
 
   public List<GitLabMergeRequestApiResponseDto> getMergeRequests(String accessToken) {
-    // TODO 例外処理
     try {
-      var requestEntity = RequestEntity
-          .get(new URI(endpoint))
+      var token = StringUtils.isNotBlank(accessToken) ? accessToken : projectAccessToken;
+      var responseEntity = restClient.get()
+          .uri(new URI(endpoint))
           .accept(MediaType.APPLICATION_JSON)
-          .header("Authorization",
-              "Bearer %s".formatted(StringUtils.isNotBlank(accessToken) ?
-                  accessToken : projectAccessToken))
-          .build();
-      log.info("api url -> {}", requestEntity.getUrl());
-      var responseEntity = restTemplate.exchange(requestEntity,
-          GitLabMergeRequestApiResponseDto[].class);
-      log.debug("status code -> {}", responseEntity.getStatusCode());
-      var body = responseEntity.getBody();
-      return Objects.isNull(body) ? List.of() : Arrays.asList(body);
+          .header("Authorization", "Bearer %s".formatted(token))
+          .retrieve()
+          .toEntity(GitLabMergeRequestApiResponseDto[].class);
+      
+      if (responseEntity != null) {
+        log.info("status code -> {}", responseEntity.getStatusCode());
+        var body = responseEntity.getBody();
+        return Objects.isNull(body) ? List.of() : Arrays.asList(body);
+      }
+      return List.of();
     } catch (Exception e) {
       throw new GitLabApiException(e);
     }

--- a/src/main/resources/application-env.yml
+++ b/src/main/resources/application-env.yml
@@ -1,4 +1,7 @@
 app:
+  proxy:
+    host:
+    port:
   gitlab:
     project:
       id:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,9 @@
+server:
+  port: 8081
 app:
+  proxy:
+    host: ${PROXY_HOST}
+    port: ${PROXY_PORT}
   gitlab:
     host: ${GITLAB_HOST}
     project:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,3 @@
-server:
-  port: 8081
 app:
   proxy:
     host: ${PROXY_HOST}

--- a/src/test/java/io/github/tttol/mrls/MrlsApplicationTests.java
+++ b/src/test/java/io/github/tttol/mrls/MrlsApplicationTests.java
@@ -3,7 +3,10 @@ package io.github.tttol.mrls;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(properties = {"GITLAB_PROJECT_ID=dummy",
+@SpringBootTest(properties = {
+        "PROXY_HOST=dummy.com",
+        "PROXY_PORT=80",
+        "GITLAB_PROJECT_ID=dummy",
         "GITLAB_ACCESS_TOKEN=dummy",
         "GITLAB_HOST=dummy"})
 class MrlsApplicationTests {

--- a/src/test/java/io/github/tttol/mrls/controller/MrListControllerTest.java
+++ b/src/test/java/io/github/tttol/mrls/controller/MrListControllerTest.java
@@ -22,7 +22,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-@SpringBootTest(properties = {"GITLAB_PROJECT_ID=dummy",
+@SpringBootTest(properties = {
+        "PROXY_HOST=dummy.com",
+        "PROXY_PORT=80",
+        "GITLAB_PROJECT_ID=dummy",
         "GITLAB_ACCESS_TOKEN=dummy"})
 public class MrListControllerTest {
 


### PR DESCRIPTION
- HTTP_PROXY, HTTPS_PROXYを通してGitLabと通信できるよう修正
- Gradleを7.6 -> 8.6にアップデート
- Spring Bootを3.0.3 -> 3.2.5にアップデート
- JDKを17 -> 21にアップデート